### PR TITLE
Fix package imports and enable pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ documentation = "https://otobo-docs.softoft.de/administration/automation/rest-ap
 where = ["src"]
 include = ["otobo"]
 
-[tool.pytest]
+[tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+pythonpath = ["src"]

--- a/src/otobo/__init__.py
+++ b/src/otobo/__init__.py
@@ -1,9 +1,26 @@
-from .models.client_config_models import *
-from .models.request_models import TicketGetRequest, \
-    TicketSearchRequest, TicketUpdateRequest, AuthData
-from .models.response_models import *
-from client.otobo_client import OTOBOClient
-from util.otobo_errors import OTOBOError
+"""Public package interface for the OTOBO client library.
+
+Historically the project relied on implicit absolute imports which only
+worked once the package had been installed.  The test-suite imports the
+package directly from the repository, so we expose the key classes and
+utilities here using explicit relative imports.  This keeps the package
+importable without installation and avoids circular import issues.
+"""
+
+from .models.client_config_models import *  # noqa: F401,F403
+from .models.request_models import (
+    TicketGetRequest,
+    TicketSearchRequest,
+    TicketUpdateRequest,
+    AuthData,
+)
+from .models.response_models import *  # noqa: F401,F403
+from .client.otobo_client import OTOBOClient
+from .util.otobo_errors import OTOBOError
+from .util.webservice_config import create_otobo_client_config
+
+# Backwards compatibility alias; some documentation refers to this name.
+from .models.response_models import TicketResponse as OTOBOTicketCreateResponse
 
 __all__ = [
     "AuthData",
@@ -17,5 +34,6 @@ __all__ = [
     "TicketSearchRequest",
     "OTOBOClientConfig",
     "OTOBOError",
-    "OTOBOClient"
+    "OTOBOClient",
+    "create_otobo_client_config",
 ]

--- a/src/otobo/client/otobo_client.py
+++ b/src/otobo/client/otobo_client.py
@@ -6,19 +6,31 @@ import httpx
 from httpx import AsyncClient
 from pydantic import BaseModel, ValidationError
 
-from models.client_config_models import TicketOperation, OTOBOClientConfig
-from models.request_models import (
+"""Asynchronous client implementation for the OTOBO REST API.
+
+The original project used absolute imports such as ``from models...`` which
+assumed the package had been installed.  When running the tests directly
+from the source tree this resulted in ``ImportError`` because Python could
+not resolve the top level modules.  The client now uses explicit relative
+imports to reference sibling modules within the :mod:`otobo` package.  This
+allows the test-suite to import the package without performing an
+installation step.
+"""
+
+from ..models.client_config_models import TicketOperation, OTOBOClientConfig
+from ..models.request_models import (
     TicketSearchRequest,
     TicketUpdateRequest,
     TicketGetRequest,
+    TicketCreateRequest,
 )
-from models.response_models import (
+from ..models.response_models import (
     TicketSearchResponse,
-    TicketGetResponse, TicketResponse,
+    TicketGetResponse,
+    TicketResponse,
 )
-from models.ticket_models import TicketDetailOutput
-from models.request_models import TicketCreateRequest
-from util.otobo_errors import OTOBOError
+from ..models.ticket_models import TicketDetailOutput
+from ..util.otobo_errors import OTOBOError
 from http import HTTPMethod
 
 

--- a/src/otobo/models/request_models.py
+++ b/src/otobo/models/request_models.py
@@ -2,7 +2,19 @@ from typing import Optional, Union, List, Dict, Literal
 
 from pydantic import BaseModel, Field
 
-from models.ticket_models import TicketBase, ArticleDetail, DynamicFieldItem
+"""Pydantic models for request payloads sent to the OTOBO API.
+
+This module lives inside the :mod:`otobo` package which follows the
+``src`` layout.  When the test-suite tries to import these models without
+installing the package, absolute imports like ``from models.ticket_models``
+break because Python cannot resolve the top-level ``models`` package.
+
+Using explicit relative imports keeps the package self contained and makes
+it possible to run the tests directly from the repository without an
+installation step.
+"""
+
+from .ticket_models import TicketBase, ArticleDetail, DynamicFieldItem
 
 
 class AuthData(BaseModel):

--- a/src/otobo/util/webservice_config.py
+++ b/src/otobo/util/webservice_config.py
@@ -2,7 +2,18 @@ from pathlib import Path
 from typing import Dict, Any
 import yaml
 
-from otobo import TicketOperation, AuthData, OTOBOClientConfig
+"""Utilities for reading OTOBO Webservice configuration files.
+
+The original implementation imported from the top-level :mod:`otobo`
+package.  This caused a circular import when :mod:`otobo.__init__` tried to
+expose :func:`create_otobo_client_config` while this module simultaneously
+imported from :mod:`otobo`.  Using relative imports resolves the cycle and
+keeps the module usable when the package is imported directly from the
+source tree.
+"""
+
+from ..models.client_config_models import TicketOperation, OTOBOClientConfig
+from ..models.request_models import AuthData
 
 TYPE_TO_ENUM = {op.type: op for op in TicketOperation}
 


### PR DESCRIPTION
## Summary
- switch to relative imports within otobo package to avoid import errors
- expose helper function and alias in package __init__
- configure pytest to include `src` on PYTHONPATH for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53f3a861883279440fa574756e182