### PR TITLE
Add bilingual getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 An asynchronous Python client for interacting with the OTOBO REST API. Built with `httpx` and `pydantic` for type safety
 and ease of use.
 
+## Documentation
+
+- [Getting started (English)](docs/getting-started.en.md)
+- [Einstieg (Deutsch)](docs/getting-started.de.md)
+
 ## Features
 
 * **Asynchronous** HTTP requests using `httpx.AsyncClient`

--- a/docs/getting-started.de.md
+++ b/docs/getting-started.de.md
@@ -1,0 +1,54 @@
+# Erste Schritte mit dem OTOBO Python Client
+
+Der OTOBO Python Client stellt eine asynchrone Schnittstelle zur OTOBO REST API bereit. Diese Anleitung zeigt die Installation und das Anlegen eines Tickets.
+
+## Installation
+
+```bash
+pip install otobo
+```
+
+## Konfiguration
+
+```python
+from otobo import OTOBOClient, OTOBOClientConfig, AuthData, TicketCreateParams, TicketCommon, ArticleDetail, TicketOperation
+
+config = OTOBOClientConfig(
+    base_url="https://dein-otobo-server/nph-genericinterface.pl",
+    service="OTOBO",
+    auth=AuthData(UserLogin="user1", Password="SicheresPasswort"),
+    operations={
+        TicketOperation.CREATE.value: "ticket",
+        TicketOperation.SEARCH.value: "ticket/search",
+    },
+)
+
+client = OTOBOClient(config)
+```
+
+## Ticket erstellen
+
+```python
+payload = TicketCreateParams(
+    Ticket=TicketCommon(
+        Title="Neue Bestellung",
+        Queue="Vertrieb",
+        State="neu",
+        Priority="3 normal",
+        CustomerUser="kunde@example.com",
+    ),
+    Article=ArticleDetail(
+        CommunicationChannel="Email",
+        Charset="utf-8",
+        Subject="Bestellung",
+        Body="Hallo",
+        MimeType="text/plain",
+    ),
+)
+
+await client.create_ticket(payload)
+```
+
+## Weiterführende Informationen
+
+Weitere Funktionen und Beispiele finden sich im [Projekt-README](../README.md).

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -1,0 +1,54 @@
+# Getting Started with the OTOBO Python Client
+
+The OTOBO Python client provides an asynchronous interface to the OTOBO REST API. This guide shows how to install the package and create a ticket.
+
+## Installation
+
+```bash
+pip install otobo
+```
+
+## Configuration
+
+```python
+from otobo import OTOBOClient, OTOBOClientConfig, AuthData, TicketCreateParams, TicketCommon, ArticleDetail, TicketOperation
+
+config = OTOBOClientConfig(
+    base_url="https://your-otobo-server/nph-genericinterface.pl",
+    service="OTOBO",
+    auth=AuthData(UserLogin="user1", Password="SecurePassword"),
+    operations={
+        TicketOperation.CREATE.value: "ticket",
+        TicketOperation.SEARCH.value: "ticket/search",
+    },
+)
+
+client = OTOBOClient(config)
+```
+
+## Create a Ticket
+
+```python
+payload = TicketCreateParams(
+    Ticket=TicketCommon(
+        Title="New Order",
+        Queue="Sales",
+        State="new",
+        Priority="3 normal",
+        CustomerUser="customer@example.com",
+    ),
+    Article=ArticleDetail(
+        CommunicationChannel="Email",
+        Charset="utf-8",
+        Subject="Order",
+        Body="Hello",
+        MimeType="text/plain",
+    ),
+)
+
+await client.create_ticket(payload)
+```
+
+## Further Reading
+
+See the [project README](../README.md) for more features and examples.


### PR DESCRIPTION
## Summary
- add English getting started guide
- add German getting started guide
- link new documentation from README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'models')*


------
https://chatgpt.com/codex/tasks/task_e_68c53f91f9908327b54438c7604b58e7