### PR TITLE
Fix packaging and imports for src-based layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,7 @@ documentation = "https://otobo-docs.softoft.de/administration/automation/rest-ap
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["otobo"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-pythonpath = ["src"]

--- a/src/otobo/__init__.py
+++ b/src/otobo/__init__.py
@@ -1,39 +1,32 @@
-"""Public package interface for the OTOBO client library.
-
-Historically the project relied on implicit absolute imports which only
-worked once the package had been installed.  The test-suite imports the
-package directly from the repository, so we expose the key classes and
-utilities here using explicit relative imports.  This keeps the package
-importable without installation and avoids circular import issues.
-"""
-
-from .models.client_config_models import *  # noqa: F401,F403
-from .models.request_models import (
-    TicketGetRequest,
-    TicketSearchRequest,
-    TicketUpdateRequest,
-    AuthData,
-)
-from .models.response_models import *  # noqa: F401,F403
 from .client.otobo_client import OTOBOClient
-from .util.otobo_errors import OTOBOError
-from .util.webservice_config import create_otobo_client_config
-
-# Backwards compatibility alias; some documentation refers to this name.
-from .models.response_models import TicketResponse as OTOBOTicketCreateResponse
+from .models.client_config_models import OTOBOClientConfig, TicketOperation
+from .models.request_models import (
+    TicketCreateRequest,
+    TicketGetRequest,
+    TicketUpdateRequest,
+    TicketSearchRequest,
+)
+from .models.response_models import (
+    TicketResponse,
+    TicketGetResponse,
+    TicketSearchResponse,
+    TicketDetailOutput,
+    OTOBOError,
+)
 
 __all__ = [
-    "AuthData",
+    "OTOBOClient",
+    "OTOBOClientConfig",
     "TicketOperation",
-    "OTOBOTicketCreateResponse",
-    "TicketUpdateResponse",
-    "TicketSearchResponse",
-    "TicketGetResponse",
+    "TicketCreateRequest",
     "TicketGetRequest",
     "TicketUpdateRequest",
     "TicketSearchRequest",
-    "OTOBOClientConfig",
+    "TicketResponse",
+    "TicketGetResponse",
+    "TicketSearchResponse",
+    "TicketDetailOutput",
     "OTOBOError",
-    "OTOBOClient",
-    "create_otobo_client_config",
 ]
+
+__version__ = "0.1.0"

--- a/src/otobo/client/otobo_client.py
+++ b/src/otobo/client/otobo_client.py
@@ -6,31 +6,22 @@ import httpx
 from httpx import AsyncClient
 from pydantic import BaseModel, ValidationError
 
-"""Asynchronous client implementation for the OTOBO REST API.
+"""Asynchronous client implementation for the OTOBO REST API."""
 
-The original project used absolute imports such as ``from models...`` which
-assumed the package had been installed.  When running the tests directly
-from the source tree this resulted in ``ImportError`` because Python could
-not resolve the top level modules.  The client now uses explicit relative
-imports to reference sibling modules within the :mod:`otobo` package.  This
-allows the test-suite to import the package without performing an
-installation step.
-"""
-
-from ..models.client_config_models import TicketOperation, OTOBOClientConfig
-from ..models.request_models import (
+from otobo.models.client_config_models import TicketOperation, OTOBOClientConfig
+from otobo.models.request_models import (
     TicketSearchRequest,
     TicketUpdateRequest,
     TicketGetRequest,
     TicketCreateRequest,
 )
-from ..models.response_models import (
+from otobo.models.response_models import (
     TicketSearchResponse,
     TicketGetResponse,
     TicketResponse,
 )
-from ..models.ticket_models import TicketDetailOutput
-from ..util.otobo_errors import OTOBOError
+from otobo.models.ticket_models import TicketDetailOutput
+from otobo.util.otobo_errors import OTOBOError
 from http import HTTPMethod
 
 

--- a/src/otobo/models/client_config_models.py
+++ b/src/otobo/models/client_config_models.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from pydantic import BaseModel, Field
 
-from .request_models import AuthData
+from otobo.models.request_models import AuthData
 
 
 class TicketOperation(Enum):

--- a/src/otobo/models/request_models.py
+++ b/src/otobo/models/request_models.py
@@ -2,19 +2,9 @@ from typing import Optional, Union, List, Dict, Literal
 
 from pydantic import BaseModel, Field
 
-"""Pydantic models for request payloads sent to the OTOBO API.
+"""Pydantic models for request payloads sent to the OTOBO API."""
 
-This module lives inside the :mod:`otobo` package which follows the
-``src`` layout.  When the test-suite tries to import these models without
-installing the package, absolute imports like ``from models.ticket_models``
-break because Python cannot resolve the top-level ``models`` package.
-
-Using explicit relative imports keeps the package self contained and makes
-it possible to run the tests directly from the repository without an
-installation step.
-"""
-
-from .ticket_models import TicketBase, ArticleDetail, DynamicFieldItem
+from otobo.models.ticket_models import TicketBase, ArticleDetail, DynamicFieldItem
 
 
 class AuthData(BaseModel):

--- a/src/otobo/models/response_models.py
+++ b/src/otobo/models/response_models.py
@@ -2,7 +2,8 @@ from typing import Union, List, Optional
 
 from pydantic import BaseModel
 
-from .ticket_models import TicketDetailOutput
+from otobo.models.ticket_models import TicketDetailOutput
+from otobo.util.otobo_errors import OTOBOError
 
 class TicketResponse(BaseModel):
     Ticket: Optional[TicketDetailOutput] = None

--- a/src/otobo/util/webservice_config.py
+++ b/src/otobo/util/webservice_config.py
@@ -2,18 +2,10 @@ from pathlib import Path
 from typing import Dict, Any
 import yaml
 
-"""Utilities for reading OTOBO Webservice configuration files.
+"""Utilities for reading OTOBO Webservice configuration files."""
 
-The original implementation imported from the top-level :mod:`otobo`
-package.  This caused a circular import when :mod:`otobo.__init__` tried to
-expose :func:`create_otobo_client_config` while this module simultaneously
-imported from :mod:`otobo`.  Using relative imports resolves the cycle and
-keeps the module usable when the package is imported directly from the
-source tree.
-"""
-
-from ..models.client_config_models import TicketOperation, OTOBOClientConfig
-from ..models.request_models import AuthData
+from otobo.models.client_config_models import TicketOperation, OTOBOClientConfig
+from otobo.models.request_models import AuthData
 
 TYPE_TO_ENUM = {op.type: op for op in TicketOperation}
 

--- a/tests/e2e/client_usage.py
+++ b/tests/e2e/client_usage.py
@@ -13,11 +13,11 @@ from otobo import (
     OTOBOClient,
     OTOBOClientConfig,
     TicketOperation,
-    AuthData,
     TicketSearchRequest,
     TicketGetRequest,
     TicketUpdateRequest,
 )
+from otobo.models.request_models import AuthData
 
 # --- Setup Logging ---
 logging.basicConfig(

--- a/tests/e2e/test_client_config_models.py
+++ b/tests/e2e/test_client_config_models.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import textwrap
 from typing import Dict
 
-from otobo import AuthData, create_otobo_client_config, OTOBOClientConfig, TicketOperation
+from otobo.models.request_models import AuthData
+from otobo.util.webservice_config import create_otobo_client_config
+from otobo.models.client_config_models import OTOBOClientConfig, TicketOperation
 
 
 def _write(tmp_path: Path, name: str, content: str) -> Path:

--- a/tests/unit/test_otobo_client.py
+++ b/tests/unit/test_otobo_client.py
@@ -1,27 +1,26 @@
 import json
-import sys
-from pathlib import Path
 
 import httpx
 import pytest
 import pytest_asyncio
 from http import HTTPMethod
 
-# Ensure the package uses its expected import layout
-sys.path.append(str(Path(__file__).resolve().parents[2] / "src/otobo"))
-
-from client.otobo_client import OTOBOClient
-from models.client_config_models import OTOBOClientConfig, TicketOperation
-from models.request_models import (
+from otobo.client.otobo_client import OTOBOClient
+from otobo.models.client_config_models import OTOBOClientConfig, TicketOperation
+from otobo.models.request_models import (
     AuthData,
     TicketCreateRequest,
     TicketGetRequest,
     TicketSearchRequest,
     TicketUpdateRequest,
 )
-from models.response_models import TicketGetResponse, TicketResponse, TicketSearchResponse
-from models.ticket_models import TicketDetailOutput
-from util.otobo_errors import OTOBOError
+from otobo.models.response_models import (
+    TicketGetResponse,
+    TicketResponse,
+    TicketSearchResponse,
+)
+from otobo.models.ticket_models import TicketDetailOutput
+from otobo.util.otobo_errors import OTOBOError
 
 
 @pytest.fixture

--- a/tests/update_example.py
+++ b/tests/update_example.py
@@ -1,5 +1,4 @@
-from models.ticket_models import DynamicFieldItem
-from src.otobo import ArticleDetail
+from otobo.models.ticket_models import DynamicFieldItem, ArticleDetail
 
 Ticket = [TicketDetail(TicketID=12, TicketNumber='2024100201000065',
         Title='ticket - <OTOBO_TICKET_DynamicField_customerUserIHKAbteilung_Value>',


### PR DESCRIPTION
## Summary
- configure setuptools to discover packages under `src`
- expose a focused public API in `otobo.__init__`
- switch package and test imports to absolute paths and add typing marker

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55c7728008327ad59c760c801c9fb