### PR TITLE
refactor e2e client usage

### DIFF
--- a/tests/e2e/demo_system_env
+++ b/tests/e2e/demo_system_env
@@ -1,4 +1,5 @@
-OTOBO_BASE_URL=""http://52.57.217.182/otobo/nph-genericinterface.pl"
+OTOBO_BASE_URL="http://52.57.217.182/otobo/nph-genericinterface.pl"
 OTOBO_SERVICE="OpenTicketAI"
 OTOBO_TEST_USER="openticketai_ws"
 OTOBO_TEST_PASSWORD="SqCXLWGqq6H2Cou0aa8U"
+


### PR DESCRIPTION
## Summary
- fix e2e client demo to import current request models and load auth from demo system file
- correct demo_system_env format

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src python tests/e2e/client_usage.py` *(fails: TicketCreate.AuthFail: TicketCreate: User could not be authenticated!)*

------
https://chatgpt.com/codex/tasks/task_e_68c5822f9c4c8327b23a367708a9a998