### PR TITLE
Add e2e coverage for search_and_get variations

### DIFF
--- a/tests/e2e/client_usage.py
+++ b/tests/e2e/client_usage.py
@@ -1,3 +1,5 @@
+import asyncio
+import random
 import time
 import logging
 import pytest
@@ -12,6 +14,56 @@ from otobo import (
 from otobo.models.ticket_models import TicketBase, ArticleDetail
 
 logger = logging.getLogger("e2e_test")
+
+
+async def _create_basic_ticket(otobo_client, title: str) -> tuple[int, str]:
+    create_req = TicketCreateRequest(
+        Ticket=TicketBase(
+            Title=title,
+            Queue="Raw",
+            State="new",
+            Priority="3 normal",
+            Type="Incident",
+            CustomerUser="customer@localhost.de",
+        ),
+        Article=ArticleDetail(
+            Subject="Integration Test",
+            Body="pytest body",
+            ContentType="text/plain; charset=utf-8",
+        ),
+    )
+    ticket = await otobo_client.create_ticket(create_req)
+    ticket_id = int(ticket.TicketID)
+    ticket_number = ticket.TicketNumber
+    assert ticket_number is not None
+    return ticket_id, ticket_number
+
+
+async def _wait_for_ticket_ids(
+    otobo_client,
+    query: TicketSearchRequest,
+    expected_ids: list[int],
+    attempts: int = 6,
+    delay: float = 1.0,
+) -> list[int]:
+    expected_set = set(expected_ids)
+    for attempt in range(attempts):
+        current_ids = await otobo_client.search_tickets(query)
+        filtered = [int(tid) for tid in current_ids if int(tid) in expected_set]
+        if set(filtered) == expected_set and len(filtered) == len(expected_ids):
+            logger.info("Found expected ticket ids on attempt %s: %s", attempt + 1, filtered)
+            return filtered
+        logger.info(
+            "Waiting for ticket ids. Attempt %s/%s. Expected=%s, got=%s",
+            attempt + 1,
+            attempts,
+            expected_ids,
+            current_ids,
+        )
+        await asyncio.sleep(delay)
+    raise AssertionError(
+        f"Search results did not return expected ticket ids after {attempts} attempts"
+    )
 
 
 @pytest.mark.asyncio
@@ -67,3 +119,46 @@ async def test_ticket_flow(otobo_client):
         TicketSearchRequest(Queues=["Raw"])
     )
     assert isinstance(combined, list)
+
+
+@pytest.mark.asyncio
+async def test_search_and_get_multiple_cases(otobo_client):
+    ts = int(time.time())
+    titles = [f"pytest-batch-{ts}-{i}" for i in range(3)]
+
+    created = [await _create_basic_ticket(otobo_client, title) for title in titles]
+    ticket_ids = [ticket_id for ticket_id, _ in created]
+    ticket_numbers = [ticket_number for _, ticket_number in created]
+
+    search_query = TicketSearchRequest(TicketNumber=ticket_numbers)
+    search_ids = await _wait_for_ticket_ids(otobo_client, search_query, ticket_ids)
+
+    assert set(search_ids) == set(ticket_ids)
+
+    # Case 1: Fetch all matching tickets (max_tickets larger than available)
+    full_details = await otobo_client.search_and_get(search_query, max_tickets=5)
+    full_ids = [int(ticket.TicketID) for ticket in full_details]
+    assert full_ids == search_ids
+
+    # Case 2: Respect max_tickets limit
+    limited_details = await otobo_client.search_and_get(search_query, max_tickets=2)
+    limited_ids = [int(ticket.TicketID) for ticket in limited_details]
+    assert limited_ids == search_ids[:2]
+
+    # Case 3: Shuffle order deterministically when requested
+    random_state = random.getstate()
+    try:
+        random.seed(0)
+        shuffled_details = await otobo_client.search_and_get(
+            search_query, max_tickets=3, shuffle=True
+        )
+        shuffled_ids = [int(ticket.TicketID) for ticket in shuffled_details]
+
+        random.seed(0)
+        expected_shuffled = search_ids.copy()
+        random.shuffle(expected_shuffled)
+        expected_shuffled = expected_shuffled[:3]
+
+        assert shuffled_ids == expected_shuffled
+    finally:
+        random.setstate(random_state)


### PR DESCRIPTION
## Summary
- add helpers in the e2e suite to create tickets and wait for search visibility
- add an end-to-end test that exercises search_and_get with full, limited, and shuffled retrieval

## Testing
- PYTHONPATH=src python -m pytest tests/unit -k search_and_get --maxfail=1
- pip install -e . *(fails: missing mariadb_config required for MariaDB Connector/C)*

------
https://chatgpt.com/codex/tasks/task_e_68c88ba78f3483278431c869df668c1b