### PR TITLE
Refactor webservice generators for shared use

### DIFF
--- a/src/otobo_znuny_python_client/scripts/setup_webservices.py
+++ b/src/otobo_znuny_python_client/scripts/setup_webservices.py
@@ -1,223 +1,97 @@
 from __future__ import annotations
 
-import copy
 import re
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated
 
 import typer
-import yaml
-from pydantic import BaseModel
 
-from otobo_znuny_python_client.domain_models.ticket_operation import TicketOperation
-from otobo_znuny_python_client.scripts.webservice_util import generate_enabled_operations_list
+from otobo_znuny_python_client.setup.webservices import (
+    AUTH_EXPECTATIONS_DOC,
+    DEFAULT_BASIC_AUTH_PASSWORD,
+    DEFAULT_BASIC_AUTH_USER,
+    DEFAULT_FRAMEWORK_VERSION,
+    SUPPORTED_OPERATIONS_DOC,
+    WebServiceGenerator,
+    generate_enabled_operations_list,
+)
 
-
-class NoAliasDumper(yaml.SafeDumper):
-    def ignore_aliases(self, data):
-        return True
-
+CLI_DESCRIPTION = "\n\n".join([
+    "Generate secure OTOBO/Znuny web service YAML.",
+    SUPPORTED_OPERATIONS_DOC,
+    AUTH_EXPECTATIONS_DOC,
+])
 
 app = typer.Typer(
     add_completion=False,
-    help="Generate secure OTOBO/Znuny web service YAML.",
+    help=CLI_DESCRIPTION,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 
 
-class RouteMappingConfig(BaseModel):
-    Route: str
-    RequestMethod: list[str]
-    ParserBackend: Literal["JSON"] = "JSON"
-
-
-class ProviderOperationConfig(BaseModel):
-    Type: str
-    Description: str
-    IncludeTicketData: Literal["0", "1"]
-    MappingInbound: dict[str, Any]
-    MappingOutbound: dict[str, Any]
-
-
-class OperationSpec(BaseModel):
-    op: TicketOperation
-    route: str
-    description: str
-    methods: list[str]
-    include_ticket_data: Literal["0", "1"]
-
-
-class WebServiceGenerator:
-    DEFAULT_SPECS: dict[TicketOperation, OperationSpec] = {
-        TicketOperation.CREATE: OperationSpec(
-            op=TicketOperation.CREATE,
-            route="ticket-create",
-            description="Creates a new ticket.",
-            methods=["POST"],
-            include_ticket_data="1",
-        ),
-        TicketOperation.GET: OperationSpec(
-            op=TicketOperation.GET,
-            route="ticket-get",
-            description="Retrieves a ticket by its ID.",
-            methods=["POST"],
-            include_ticket_data="1",
-        ),
-        TicketOperation.SEARCH: OperationSpec(
-            op=TicketOperation.SEARCH,
-            route="ticket-search",
-            description="Searches for tickets based on criteria.",
-            methods=["POST"],
-            include_ticket_data="0",
-        ),
-        TicketOperation.UPDATE: OperationSpec(
-            op=TicketOperation.UPDATE,
-            route="ticket-update",
-            description="Updates an existing ticket.",
-            methods=["PUT"],
-            include_ticket_data="1",
-        ),
-    }
-
-    def __init__(self):
-        self.route_mapping: dict[str, dict] = {}
-        self.operations: dict[str, dict] = {}
-
-    def generate_yaml(
-            self,
-            webservice_name: str,
-            enabled_operations: list[TicketOperation],
-            restricted_user: str | None = None,
-            framework_version: str = "11.0.0",
-    ) -> str:
-        name = self._validate_name(webservice_name)
-        enabled_operation_specs: list[OperationSpec] = [
-            self.DEFAULT_SPECS[o] for o in enabled_operations if o in self.DEFAULT_SPECS
-        ]
-        if not enabled_operation_specs:
-            raise ValueError("No operations enabled.")
-        inbound_base = self._create_inbound_mapping(restricted_user)
-        description = self._description(name, restricted_user)
-
-        for s in enabled_operation_specs:
-            inbound = copy.deepcopy(inbound_base)
-            self._add_operation(s, inbound)
-
-        data = {
-            "Debugger": {"DebugThreshold": "debug", "TestMode": "0"},
-            "Description": description,
-            "FrameworkVersion": framework_version,
-            "Provider": {
-                "Transport": {
-                    "Type": "HTTP::REST",
-                    "Config": {
-                        "MaxLength": "1000000",
-                        "KeepAlive": "",
-                        "AdditionalHeaders": "",
-                        "RouteOperationMapping": self.route_mapping,
-                    },
-                },
-                "Operation": self.operations,
-            },
-            "RemoteSystem": "",
-            "Requester": {"Transport": {"Type": ""}},
-        }
-        return yaml.dump(data, sort_keys=False, indent=2, Dumper=NoAliasDumper, explicit_start=True)
-
-    def write_yaml_to_file(self, webservice_name: str,
-                           enabled_operations: list[TicketOperation],
-                           restricted_user: str | None = None,
-                           framework_version: str = "11.0.0",
-                           file_path: str | Path = "webservice_config.yml") -> None:
-        out = self.generate_yaml(
-            webservice_name=webservice_name,
-            enabled_operations=enabled_operations,
-            restricted_user=restricted_user,
-            framework_version=framework_version,
+def _validate_name(name: str) -> str:
+    if not name:
+        raise typer.BadParameter("Webservice name cannot be empty.")
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", name):
+        raise typer.BadParameter(
+            "Name must start with a letter and contain only A–Z, a–z, 0–9, _ or -.",
         )
-        Path(file_path).write_text(out, encoding="utf-8")
-
-    def _add_operation(self, s: OperationSpec, inbound: dict[str, Any]) -> None:
-        self.route_mapping[s.op.operation_type] = RouteMappingConfig(
-            Route=f"/{s.route}",
-            RequestMethod=s.methods,
-        ).model_dump()
-        self.operations[s.op.operation_type] = ProviderOperationConfig(
-            Type=s.op.type,
-            Description=s.description,
-            IncludeTicketData=s.include_ticket_data,
-            MappingInbound=inbound,
-            MappingOutbound=self._outbound_mapping(),
-        ).model_dump()
-
-    def _validate_name(self, name: str) -> str:
-        if not name:
-            raise ValueError("Webservice name cannot be empty.")
-        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", name):
-            raise ValueError("Name must start with a letter and contain only A–Z, a–z, 0–9, _ or -.")
-        return name
-
-    def _description(self, name: str, user: str | None) -> str:
-        if user:
-            return f"Webservice for '{name}'. Restricted to user '{user}'."
-        return f"Webservice for '{name}'. Accessible by all permitted agents."
-
-    def _create_simple_empty_mapping(self) -> dict[str, Any]:
-        return {
-            "Type": "Simple",
-            "Config": {
-                "KeyMapDefault": self._create_empty_mapping(),
-                "ValueMapDefault": self._create_empty_mapping(),
-            },
-        }
-
-    def _create_empty_mapping(self) -> dict[str, Any]:
-        return {"MapType": "Keep", "MapTo": ""}
-
-    def _create_inbound_mapping(self, restricted_user: str | None) -> dict[str, Any]:
-        if restricted_user:
-            return {
-                "Type": "Simple",
-                "Config": {
-                    "KeyMapDefault": self._create_empty_mapping(),
-                    "KeyMapExact": {"UserLogin": "UserLogin"},
-                    "ValueMap": {
-                        "UserLogin": {"ValueMapRegEx": {".*": restricted_user}},
-                    },
-                    "ValueMapDefault": self._create_empty_mapping(),
-                },
-            }
-        return self._create_simple_empty_mapping()
-
-    def _outbound_mapping(self) -> dict[str, Any]:
-        return self._create_simple_empty_mapping()
+    return name
 
 
-@app.command()
+@app.command(help="\n\n".join([SUPPORTED_OPERATIONS_DOC, AUTH_EXPECTATIONS_DOC]))
 def generate(
         name: Annotated[str, typer.Option("--name", rich_help_panel="Required")],
-        enabled_operations_raw: list[str] = typer.Option(
-            ...,
-            "--op",
-            "-o",
-            help="Repeat for each: get, search, create, update",
-            case_sensitive=False,
-        ),
+        enabled_operations_raw: Annotated[
+            list[str],
+            typer.Option(
+                "--op",
+                "-o",
+                help="Repeat for each: get, search, create, update",
+                case_sensitive=False,
+                rich_help_panel="Operations",
+            ),
+        ],
         allow_user: Annotated[
             str | None,
-            typer.Option("--allow-user", metavar="USERNAME", rich_help_panel="Auth"),
+            typer.Option(
+                "--allow-user",
+                metavar="USERNAME",
+                rich_help_panel="Auth",
+                help="Limit access to a dedicated agent user (sets BasicAuth user).",
+            ),
         ] = None,
         allow_all_agents: Annotated[
-            bool, typer.Option("--allow-all-agents", rich_help_panel="Auth"),
+            bool,
+            typer.Option(
+                "--allow-all-agents",
+                rich_help_panel="Auth",
+                help="Allow any authenticated agent (uses shared BasicAuth user).",
+            ),
         ] = False,
+        password: Annotated[
+            str,
+            typer.Option(
+                "--password",
+                rich_help_panel="Auth",
+                help="Password assigned to the BasicAuth user.",
+            ),
+        ] = DEFAULT_BASIC_AUTH_PASSWORD,
         version: Annotated[
-            str, typer.Option("--version", rich_help_panel="Optional"),
-        ] = "11.0.0",
+            str,
+            typer.Option("--version", rich_help_panel="Optional"),
+        ] = DEFAULT_FRAMEWORK_VERSION,
         file: Annotated[
-            str | None,
-            typer.Option("--file", metavar="FILENAME", rich_help_panel="Optional"),
+            Path | None,
+            typer.Option("--file", metavar="FILENAME", rich_help_panel="Output"),
         ] = None,
-):
+) -> None:
+    try:
+        validated_name = _validate_name(name)
+    except typer.BadParameter as exc:
+        typer.secho(f"Error: {exc}", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
     if not (allow_user or allow_all_agents):
         typer.secho(
             "Error: You must specify an authentication mode.", fg=typer.colors.RED,
@@ -229,36 +103,36 @@ def generate(
             fg=typer.colors.RED,
         )
         raise typer.Exit(code=1)
-    enabled_operations: list[TicketOperation] = generate_enabled_operations_list(
-        enabled_operations_raw,
-    )
-    gen = WebServiceGenerator()
-    try:
-        if file:
-            gen.write_yaml_to_file(
-                webservice_name=name,
-                enabled_operations=enabled_operations,
-                restricted_user=allow_user if allow_user else None,
-                framework_version=version,
-                file_path=file,
-            )
-            typer.secho(
-                "Successfully generated webservice configuration.", fg=typer.colors.GREEN,
-            )
-            typer.secho(f"File: {file}")
-        else:
-            out = gen.generate_yaml(
-                webservice_name=name,
-                enabled_operations=enabled_operations,
-                restricted_user=allow_user if allow_user else None,
-                framework_version=version,
-            )
-            typer.secho("--- Generated YAML ---", bold=True)
-            typer.echo(out)
 
-    except ValueError as e:
-        typer.secho(f"Error: {e}", fg=typer.colors.RED)
+    enabled_operations = generate_enabled_operations_list(enabled_operations_raw)
+    if not enabled_operations:
+        typer.secho("Error: No valid operations specified.", fg=typer.colors.RED)
         raise typer.Exit(code=1)
+
+    description = WebServiceGenerator.build_description(
+        name=validated_name,
+        restricted_user=allow_user,
+        allow_all_agents=allow_all_agents,
+    )
+    generator = WebServiceGenerator(
+        name=validated_name,
+        description=description,
+        framework_version=version,
+        basic_auth_user=allow_user or DEFAULT_BASIC_AUTH_USER,
+        basic_auth_password=password,
+    )
+
+    config = generator.build_config(enabled_operations)
+
+    if file:
+        generator.save_to_file(config, file)
+        typer.secho(
+            "Successfully generated webservice configuration.", fg=typer.colors.GREEN,
+        )
+        typer.secho(f"File: {file}")
+    else:
+        typer.secho("--- Generated YAML ---", bold=True)
+        typer.echo(generator.dump_yaml(config))
 
 
 if __name__ == "__main__":

--- a/src/otobo_znuny_python_client/scripts/webservice_util.py
+++ b/src/otobo_znuny_python_client/scripts/webservice_util.py
@@ -1,14 +1,6 @@
-from otobo_znuny_python_client.domain_models.ticket_operation import TicketOperation
+from otobo_znuny_python_client.setup.webservices.utils import (
+    OPERATIONS,
+    generate_enabled_operations_list,
+)
 
-OPERATIONS: dict[str, TicketOperation] = {
-    "get": TicketOperation.GET,
-    "search": TicketOperation.SEARCH,
-    "create": TicketOperation.CREATE,
-    "update": TicketOperation.UPDATE,
-}
-
-
-def generate_enabled_operations_list(
-        enabled_operations: list[str],
-) -> list[TicketOperation]:
-    return [OPERATIONS[s.lower().strip()] for s in enabled_operations if s.lower().strip() in OPERATIONS]
+__all__ = ["OPERATIONS", "generate_enabled_operations_list"]

--- a/src/otobo_znuny_python_client/setup/webservices/__init__.py
+++ b/src/otobo_znuny_python_client/setup/webservices/__init__.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
-from otobo_znuny_python_client.setup.webservices.generator import WebServiceGenerator
+from otobo_znuny_python_client.setup.webservices.generator import (
+    AUTH_EXPECTATIONS_DOC,
+    DEFAULT_BASIC_AUTH_PASSWORD,
+    DEFAULT_BASIC_AUTH_USER,
+    DEFAULT_FRAMEWORK_VERSION,
+    SUPPORTED_OPERATION_SPECS,
+    SUPPORTED_OPERATIONS_DOC,
+    WebServiceGenerator,
+)
 from otobo_znuny_python_client.setup.webservices.utils import generate_enabled_operations_list
 
-__all__ = ["WebServiceGenerator", "generate_enabled_operations_list"]
+__all__ = [
+    "AUTH_EXPECTATIONS_DOC",
+    "DEFAULT_BASIC_AUTH_PASSWORD",
+    "DEFAULT_BASIC_AUTH_USER",
+    "DEFAULT_FRAMEWORK_VERSION",
+    "SUPPORTED_OPERATION_SPECS",
+    "SUPPORTED_OPERATIONS_DOC",
+    "WebServiceGenerator",
+    "generate_enabled_operations_list",
+]


### PR DESCRIPTION
## Summary
- centralize the webservice generator defaults, supported operations, and authentication help in the shared setup module
- update the setup_webservices CLI to delegate to the shared generator and share its configuration defaults with other scripts
- reuse the shared operations helper inside the scripts package to avoid duplicate mappings

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68fa8cba84d08327bb82ea94070b35cb