### PR TITLE
Fix getting started import formatting

### DIFF
--- a/docs/getting-started.de.md
+++ b/docs/getting-started.de.md
@@ -12,9 +12,15 @@ pip install otobo
 ## Konfiguration
 
 ```python
-from otobo_znuny_python_client import OTOBOClient, OTOBOClientConfig, AuthData, TicketCreateParams, TicketCommon, ArticleDetail,
-
-TicketOperation
+from otobo_znuny_python_client import (
+    OTOBOClient,
+    OTOBOClientConfig,
+    AuthData,
+    TicketCreateParams,
+    TicketCommon,
+    ArticleDetail,
+    TicketOperation,
+)
 
 config = OTOBOClientConfig(
     base_url="https://dein-otobo-server/nph-genericinterface.pl",

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -12,10 +12,15 @@ pip install otobo
 ## Configuration
 
 ```python
-from otobo_znuny_python_client import OTOBOClient, OTOBOClientConfig, AuthData, TicketCreateParams, TicketCommon,
+from otobo_znuny_python_client import (
+    OTOBOClient,
+    OTOBOClientConfig,
+    AuthData,
+    TicketCreateParams,
+    TicketCommon,
     ArticleDetail,
-
-TicketOperation
+    TicketOperation,
+)
 
 config = OTOBOClientConfig(
     base_url="https://your-otobo-server/nph-genericinterface.pl",


### PR DESCRIPTION
## Summary
- format the getting started import block using a parenthesized list for readability
- include TicketOperation within the import example in both language guides

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68fa918d78548327aacb83f13093eea5